### PR TITLE
Remove json import

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 import streamlit as st
 import pandas as pd
 import requests
-import json
 import matplotlib.pyplot as plt
 
 st.set_page_config(layout="wide", page_title="Crypto Market Pulse Dashboard")
@@ -50,10 +49,10 @@ def fetch_json_from_url(url, timeout=None):
     try:
         r = requests.get(url, headers=headers, timeout=timeout)
         r.raise_for_status()
-        return json.loads(r.text)
+        return r.json()
     except requests.RequestException as exc:
         st.error(f"Request failed: {exc}")
-    except json.JSONDecodeError as exc:
+    except ValueError as exc:
         st.error(f"JSON decode failed: {exc}")
     return {}
 


### PR DESCRIPTION
## Summary
- drop unused json import from app.py
- rely on Response.json() for JSON parsing

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: StreamlitSecretNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68644c4508b8832392f4ef67af9ede60