### PR TITLE
Add utils module with JSON fetch helper and tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+python_files = tests/test_*.py
+addopts = -ra

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import requests
+from unittest.mock import Mock, patch
+
+from utils import fetch_json_from_url
+
+
+def test_fetch_json_success():
+    mock_resp = Mock()
+    mock_resp.json.return_value = {"foo": "bar"}
+    mock_resp.raise_for_status.return_value = None
+    with patch('requests.get', return_value=mock_resp) as mock_get:
+        data = fetch_json_from_url('http://example.com')
+        mock_get.assert_called_once_with('http://example.com', timeout=None)
+        mock_resp.json.assert_called_once()
+        assert data == {"foo": "bar"}
+
+
+def test_fetch_json_http_error():
+    mock_resp = Mock()
+    mock_resp.raise_for_status.side_effect = requests.HTTPError('boom')
+    with patch('requests.get', return_value=mock_resp):
+        data = fetch_json_from_url('http://bad')
+        assert data == {}

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,16 @@
+import json
+import requests
+
+
+def fetch_json_from_url(url, timeout=None):
+    """Fetch JSON data from a URL.
+
+    Returns an empty dict on error.
+    """
+    try:
+        r = requests.get(url, timeout=timeout)
+        r.raise_for_status()
+        return r.json()
+    except (requests.RequestException, json.JSONDecodeError) as exc:
+        print(f"Error fetching {url}: {exc}")
+        return {}


### PR DESCRIPTION
## Summary
- add new `fetch_json_from_url` helper in `utils.py` using `r.json()`
- test this helper in `tests/test_utils.py`
- configure pytest to only run our tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68644c47b15c8323a40522a8d36cec5a