### PR TITLE
Add configurable alert thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,18 @@ web interface.
 2. Create `.streamlit/secrets.toml` and add your GitHub token so the app can
    fetch the remote data:
    ```toml
-   GITHUB_TOKEN = "<your token>"
+  GITHUB_TOKEN = "<your token>"
+  ```
+   You can also configure alert thresholds:
+   ```toml
+   [thresholds]
+   liquidation_percentile = 95  # percentile for liquidation spikes
+   funding_rate = 0.01          # funding rate alert level
+
+   [asset_multipliers]
+   BTCUSDT = 1.0                # per-asset multiplier for liquidation alerts
    ```
+   All of these values can also be adjusted from the sidebar once the app is running.
 3. Start the application:
    ```bash
    streamlit run app.py


### PR DESCRIPTION
## Summary
- allow configuring liquidation and funding rate thresholds
- derive thresholds from sidebar controls or secrets
- document available config values in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686450104dac8323ba3e32cadb15b49f