### PR TITLE
Unify fetch helper between app and utils

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,8 @@ import pandas as pd
 import requests
 import matplotlib.pyplot as plt
 
+from utils import fetch_json_from_url
+
 st.set_page_config(layout="wide", page_title="Crypto Market Pulse Dashboard")
 
 # --- GitHub config ---
@@ -40,23 +42,16 @@ sel_file = pulse_files[pulse_dates.index(date_idx)]
 sel_info = next(f for f in files_info if f['name'] == sel_file)
 
 @st.cache_data(ttl=60*5)
-def fetch_json_from_url(url, timeout=None):
-    """Fetch JSON data from a URL with optional timeout.
+def fetch_cached_json(url, timeout=None):
+    """Cached wrapper around :func:`utils.fetch_json_from_url`."""
+    return fetch_json_from_url(
+        url,
+        timeout=timeout,
+        headers=headers,
+        on_error=st.error,
+    )
 
-    On network or decoding errors an empty dict is returned and the error is
-    shown via ``st.error``.
-    """
-    try:
-        r = requests.get(url, headers=headers, timeout=timeout)
-        r.raise_for_status()
-        return r.json()
-    except requests.RequestException as exc:
-        st.error(f"Request failed: {exc}")
-    except ValueError as exc:
-        st.error(f"JSON decode failed: {exc}")
-    return {}
-
-data = fetch_json_from_url(sel_info['download_url'])
+data = fetch_cached_json(sel_info['download_url'])
 
 # --- Prepare asset DataFrames ---
 assets = {}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ def test_fetch_json_success():
     mock_resp.raise_for_status.return_value = None
     with patch('requests.get', return_value=mock_resp) as mock_get:
         data = fetch_json_from_url('http://example.com')
-        mock_get.assert_called_once_with('http://example.com', timeout=None)
+        mock_get.assert_called_once_with('http://example.com', headers=None, timeout=None)
         mock_resp.json.assert_called_once()
         assert data == {"foo": "bar"}
 
@@ -21,5 +21,8 @@ def test_fetch_json_http_error():
     mock_resp = Mock()
     mock_resp.raise_for_status.side_effect = requests.HTTPError('boom')
     with patch('requests.get', return_value=mock_resp):
-        data = fetch_json_from_url('http://bad')
+        on_err = Mock()
+        data = fetch_json_from_url('http://bad', on_error=on_err)
+        on_err.assert_called_once()
+        assert 'Request failed' in on_err.call_args.args[0]
         assert data == {}

--- a/utils.py
+++ b/utils.py
@@ -2,15 +2,22 @@ import json
 import requests
 
 
-def fetch_json_from_url(url, timeout=None):
-    """Fetch JSON data from a URL.
+def fetch_json_from_url(url, timeout=None, headers=None, on_error=None):
+    """Fetch JSON data from a URL with optional timeout and headers.
 
-    Returns an empty dict on error.
+    If ``on_error`` is provided it will be called with any error message,
+    otherwise the message is printed. An empty dict is returned on error.
     """
     try:
-        r = requests.get(url, timeout=timeout)
+        r = requests.get(url, headers=headers, timeout=timeout)
         r.raise_for_status()
         return r.json()
-    except (requests.RequestException, json.JSONDecodeError) as exc:
-        print(f"Error fetching {url}: {exc}")
-        return {}
+    except requests.RequestException as exc:
+        msg = f"Request failed: {exc}"
+    except (json.JSONDecodeError, ValueError) as exc:
+        msg = f"JSON decode failed: {exc}"
+    if on_error:
+        on_error(msg)
+    else:
+        print(msg)
+    return {}


### PR DESCRIPTION
## Summary
- consolidate `fetch_json_from_url` into `utils.py`
- use the helper in `app.py` with caching and Streamlit error reporting
- update tests for the new helper signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864501676e48323a82d66fd72fb7a58