### PR TITLE
Add utility helpers and tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,3 +23,19 @@ def test_fetch_json_http_error():
     with patch('requests.get', return_value=mock_resp):
         data = fetch_json_from_url('http://bad')
         assert data == {}
+
+import pandas as pd
+import numpy as np
+from utils import parse_snapshot_timestamp, liquidation_threshold
+
+
+def test_parse_snapshot_timestamp():
+    ts = parse_snapshot_timestamp('20240102_1530')
+    assert ts == pd.Timestamp('2024-01-02 15:30')
+
+
+def test_liquidation_threshold():
+    data = [1, 2, 3, 4, 5]
+    expected = pd.Series(data, dtype=float).mean() + 3 * pd.Series(data, dtype=float).std()
+    thresh = liquidation_threshold(data)
+    assert thresh == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,8 +11,9 @@ def test_fetch_json_success():
     mock_resp.json.return_value = {"foo": "bar"}
     mock_resp.raise_for_status.return_value = None
     with patch('requests.get', return_value=mock_resp) as mock_get:
-        data = fetch_json_from_url('http://example.com')
-        mock_get.assert_called_once_with('http://example.com', timeout=None)
+        headers = {"X-Test": "1"}
+        data = fetch_json_from_url('http://example.com', timeout=5, headers=headers)
+        mock_get.assert_called_once_with('http://example.com', headers=headers, timeout=5)
         mock_resp.json.assert_called_once()
         assert data == {"foo": "bar"}
 
@@ -20,12 +21,28 @@ def test_fetch_json_success():
 def test_fetch_json_http_error():
     mock_resp = Mock()
     mock_resp.raise_for_status.side_effect = requests.HTTPError('boom')
+    messages = []
+
     with patch('requests.get', return_value=mock_resp):
-        data = fetch_json_from_url('http://bad')
+        data = fetch_json_from_url('http://bad', on_error=messages.append)
         assert data == {}
 
+    assert messages and messages[0].startswith('Request failed:')
+
+
+def test_fetch_json_json_error():
+    mock_resp = Mock()
+    mock_resp.raise_for_status.return_value = None
+    mock_resp.json.side_effect = ValueError('invalid')
+    collected = []
+
+    with patch('requests.get', return_value=mock_resp):
+        data = fetch_json_from_url('http://bad-json', on_error=collected.append)
+        assert data == {}
+
+    assert collected and collected[0].startswith('JSON decode failed:')
+
 import pandas as pd
-import numpy as np
 from utils import parse_snapshot_timestamp, liquidation_threshold
 
 

--- a/utils.py
+++ b/utils.py
@@ -14,3 +14,16 @@ def fetch_json_from_url(url, timeout=None):
     except (requests.RequestException, json.JSONDecodeError) as exc:
         print(f"Error fetching {url}: {exc}")
         return {}
+
+
+def parse_snapshot_timestamp(snapshot):
+    """Convert snapshot identifier like '20240501_1500' to a pandas Timestamp."""
+    import pandas as pd
+    return pd.to_datetime(snapshot, format="%Y%m%d_%H%M")
+
+
+def liquidation_threshold(series):
+    """Return alert threshold as mean + 3 * std for a numeric sequence."""
+    import pandas as pd
+    s = pd.Series(series, dtype=float)
+    return s.mean() + 3 * s.std()

--- a/utils.py
+++ b/utils.py
@@ -2,18 +2,25 @@ import json
 import requests
 
 
-def fetch_json_from_url(url, timeout=None):
-    """Fetch JSON data from a URL.
+def fetch_json_from_url(url, timeout=None, headers=None, on_error=None):
+    """Fetch JSON data from a URL with optional timeout and headers.
 
-    Returns an empty dict on error.
+    If ``on_error`` is provided it will be called with any error message,
+    otherwise the message is printed. An empty dict is returned on error.
     """
     try:
-        r = requests.get(url, timeout=timeout)
+        r = requests.get(url, headers=headers, timeout=timeout)
         r.raise_for_status()
         return r.json()
-    except (requests.RequestException, json.JSONDecodeError) as exc:
-        print(f"Error fetching {url}: {exc}")
-        return {}
+    except requests.RequestException as exc:
+        msg = f"Request failed: {exc}"
+    except (json.JSONDecodeError, ValueError) as exc:
+        msg = f"JSON decode failed: {exc}"
+    if on_error:
+        on_error(msg)
+    else:
+        print(msg)
+    return {}
 
 
 def parse_snapshot_timestamp(snapshot):


### PR DESCRIPTION
## Summary
- add functions for snapshot timestamp parsing and liquidation threshold calculation
- unit test the new helper functions and existing fetch utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864501d22c88323be35f7e2e9196d84